### PR TITLE
Fine tune network structures

### DIFF
--- a/python/HEPCNN/torch_model_circpad.py
+++ b/python/HEPCNN/torch_model_circpad.py
@@ -13,32 +13,32 @@ class MyModel(nn.Module):
         self.conv = []
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ),
-            nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=0),
+            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
+            nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=(1,0)), ## padding=(height,width)
 
             nn.BatchNorm2d(num_features=64, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
             nn.Dropout2d(0.5),
         ])
-        self.fh = (self.fh-(3-1))//2
+        self.fh = self.fh//2
         self.fw = self.fw//2
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ),
-            nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=0),
+            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
+            nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
             nn.BatchNorm2d(num_features=128, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
             nn.Dropout2d(0.5),
         ])
-        self.fh = (self.fh-(3-1))//2
+        self.fh = self.fh//2
         self.fw = self.fw//2
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ),
-            nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=0),
+            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
+            nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
             nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
@@ -46,18 +46,16 @@ class MyModel(nn.Module):
             nn.Dropout2d(0.5),
 
         ])
-        self.fh = (self.fh-(3-1))//2
+        self.fh = self.fh//2
         self.fw = self.fw//2
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ),
-            #nn.Conv2d(256, 256, kernel_size=(3, 3), stride=2, padding=2),
-            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=0),
+            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
+            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
             nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.ReLU(),
         ])
-        self.fh = (self.fh-(3-1))
 
         self.conv = nn.Sequential(*self.conv)
 

--- a/python/HEPCNN/torch_model_circpad.py
+++ b/python/HEPCNN/torch_model_circpad.py
@@ -16,9 +16,9 @@ class MyModel(nn.Module):
             nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
             nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=(1,0)), ## padding=(height,width)
 
-            nn.BatchNorm2d(num_features=64, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=64, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
         ])
         self.fh = self.fh//2
@@ -28,9 +28,9 @@ class MyModel(nn.Module):
             nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
             nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
-            nn.BatchNorm2d(num_features=128, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=128, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
         ])
         self.fh = self.fh//2
@@ -40,9 +40,9 @@ class MyModel(nn.Module):
             nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
             nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
-            nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
 
         ])
@@ -53,8 +53,8 @@ class MyModel(nn.Module):
             nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
             nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
-            nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
         ])
 
         self.conv = nn.Sequential(*self.conv)

--- a/python/HEPCNN/torch_model_default.py
+++ b/python/HEPCNN/torch_model_default.py
@@ -13,21 +13,21 @@ class MyModel(nn.Module):
 
         self.conv = nn.Sequential(
             nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=1),
-            nn.BatchNorm2d(num_features=64, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=64, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
 
             nn.Conv2d(64, 128, kernel_size=(2, 2), stride=1, padding=1),
-            nn.BatchNorm2d(num_features=128, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=128, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
 
             nn.Conv2d(128, 256, kernel_size=(2, 2), stride=1, padding=1),
-            nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
+            nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
 
             #nn.Conv2d(256, 256, kernel_size=(3, 3), stride=2, padding=2),


### PR DESCRIPTION
Fine tune network structures
- Change the default sequence: Conv -> MaxPool -> ReLU -> BatchNorm -> Dropout
- Same-padding along pseudorapidity, manual replicated-padding (or in our word, circular padding) along the phi axis.