### PR TITLE
Faster data loading with multiprocessing

### DIFF
--- a/run/train_torch.py
+++ b/run/train_torch.py
@@ -79,14 +79,14 @@ from HEPCNN.torch_dataset import HEPCNNDataset as MyDataset
 
 sysstat.update(annotation="open_trn")
 if os.path.isdir(args.trndata):
-    trnDataset = MySplitDataset(args.trndata, args.ntrain, syslogger=sysstat)
+    trnDataset = MySplitDataset(args.trndata, args.ntrain, nWorkers=nthreads//2, syslogger=sysstat)
 else:
     trnDataset = MyDataset(args.trndata, args.ntrain, syslogger=sysstat)
 sysstat.update(annotation="read_trn")
 
 sysstat.update(annotation="open_val")
 if os.path.isdir(args.valdata):
-    valDataset = MySplitDataset(args.valdata, args.ntest, syslogger=sysstat)
+    valDataset = MySplitDataset(args.valdata, args.ntest, nWorkers=nthreads//2, syslogger=sysstat)
 else:
     valDataset = MyDataset(args.valdata, args.ntest, syslogger=sysstat)
 sysstat.update(annotation="read_val")


### PR DESCRIPTION
enable multiprocessed-image loading

Benchmark (Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz, 52threads):

With single process (250s)
```
2020-02-14 16-07-38,0.0,107917312,4646277120,0,0,start_loggin
2020-02-14 16-11-48,97.66642102677474,1613578240,53079359488,10393600,4096,train_start
```

8 processes (61s):
```
2020-02-14 16-03-33,0.0,107900928,4646277120,0,0,start_loggin
2020-02-14 16-04-34,99.65921999242711,1614209024,53079343104,10393600,8192,train_start
```

32 procs (29s):
```
2020-02-14 16-13-41,0,107909120,4646277120,0,0,start_loggin
2020-02-14 16-14-10,99.8561978717285,1613815808,53079392256,10393600,8192,train_start
```