### PR TITLE
Solve parallelized dataloader issue at nurion, minor fixes

### DIFF
--- a/python/HEPCNN/torch_model_default.py
+++ b/python/HEPCNN/torch_model_default.py
@@ -5,8 +5,8 @@ import torch.nn as nn
 class MyModel(nn.Module):
     def __init__(self, width, height, model='default'):
         super(MyModel, self).__init__()
-        self.fw = int(width/2/2/2)
-        self.fh = int(height/2/2/2)
+        self.fw = width//2//2//2
+        self.fh = height//2//2//2
 
         self.nch = 5 if '5ch' in model else 3
         self.doLog = ('log' in model)

--- a/python/HEPCNN/torch_model_original.py
+++ b/python/HEPCNN/torch_model_original.py
@@ -13,27 +13,33 @@ class MyModel(nn.Module):
 
         self.conv.extend([
             nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=1),
+            nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
         ])
-        #self.fw, self.fh = self.fw, self.fh
-        
+        self.fw, self.fh = self.fw//2, self.fh//2
+
         self.conv.extend([
             nn.Conv2d(64, 128, kernel_size=(3, 3), stride=2, padding=1),
+            nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
         ])
+        self.fw, self.fh = (self.fw)//2, (self.fh)//2
         self.fw, self.fh = (self.fw)//2, (self.fh)//2
 
         self.conv.extend([
             nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=1),
-            nn.Dropout2d(0.5),
-        ])
-        #self.fw, self.fh = self.fw, self.fh
-
-        self.conv.extend([
-            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=2, padding=1),
+            nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
         ])
-        self.fw, self.fh = (self.fw)//2, (self.fh)//2
+        self.fw, self.fh = self.fw//2, self.fh//2
+
+        if width > 128:
+            self.conv.extend([
+                nn.Conv2d(256, 256, kernel_size=(3, 3), stride=2, padding=1),
+                nn.MaxPool2d(kernel_size=(2, 2)),
+                nn.ReLU(),
+            ])
+            self.fw, self.fh = (self.fw)//2, (self.fh)//2
 
         self.conv = nn.Sequential(*self.conv)
 


### PR DESCRIPTION
multiprocessing으로 dataloader를 초기화할 때 KMP_AFFINITY 를 compact로 해 두면 CPU사용량이 1/N 으로 떨어지는 문제가 있었음.
data loading시에는 KMP_AFFINITY를 none으로 풀었다가 로딩 완료 후 원래 세팅으로 되돌리게 하는 방식으로 해결.