### PR TITLE
Switch to user defined CP module

### DIFF
--- a/python/HEPCNN/torch_model_circpad.py
+++ b/python/HEPCNN/torch_model_circpad.py
@@ -1,6 +1,18 @@
 import torch
 import torch.nn as nn
 
+class CircularPadY(nn.Module):
+    def __init__(self, pad):
+        super(CircularPadY, self).__init__()
+        self.pad = pad
+
+    def forward(self, x):
+        if x.dim() == 4:
+            return torch.cat([x, x[:,:,-2*self.pad:,:]], axis=2)
+        elif x.dim() == 3:
+            return torch.cat([x, x[:,-2*self.pad:,:]], axis=1)
+        return None
+
 class MyModel(nn.Module):
     def __init__(self, width, height, model='default'):
         super(MyModel, self).__init__()
@@ -13,8 +25,8 @@ class MyModel(nn.Module):
         self.conv = []
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
-            nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=(1,0)), ## padding=(height,width)
+            CircularPadY(1),
+            nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=(0,1)), ## padding=(height,width)
 
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
@@ -25,8 +37,8 @@ class MyModel(nn.Module):
         self.fw = self.fw//2
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
-            nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=(1,0)),
+            CircularPadY(1),
+            nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=(0,1)),
 
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
@@ -37,8 +49,8 @@ class MyModel(nn.Module):
         self.fw = self.fw//2
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
-            nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
+            CircularPadY(1),
+            nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=(0,1)),
 
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
@@ -50,8 +62,8 @@ class MyModel(nn.Module):
         self.fw = self.fw//2
 
         self.conv.extend([
-            nn.ReplicationPad2d( (2, 0, 0, 0) ), ## (left, right, top, bottom)
-            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
+            CircularPadY(1),
+            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=(0,1)),
 
             nn.ReLU(),
             nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),

--- a/python/HEPCNN/torch_model_circpad.py
+++ b/python/HEPCNN/torch_model_circpad.py
@@ -7,10 +7,11 @@ class CircularPadY(nn.Module):
         self.pad = pad
 
     def forward(self, x):
+        ## Note: attaching left&right column does the same with append 2 columns on the right hand side
         if x.dim() == 4:
-            return torch.cat([x, x[:,:,-2*self.pad:,:]], axis=2)
+            return torch.cat([x, x[:,:,-2*self.pad:,:]], dim=-2)
         elif x.dim() == 3:
-            return torch.cat([x, x[:,-2*self.pad:,:]], axis=1)
+            return torch.cat([x, x[:,-2*self.pad:,:]], dim=-2)
         return None
 
 class MyModel(nn.Module):

--- a/python/HEPCNN/torch_model_circpad.py
+++ b/python/HEPCNN/torch_model_circpad.py
@@ -75,9 +75,9 @@ class MyModel(nn.Module):
         self.fc = nn.Sequential(
             nn.Linear(self.fw*self.fh*256, 512),
             nn.ReLU(),
-            nn.Dropout2d(0.5),
+            nn.Dropout(0.5),
             nn.Linear(512, 1),
-            nn.Sigmoid(),
+            #nn.Sigmoid(),
         )
 
     def forward(self, x):

--- a/python/HEPCNN/torch_model_circpad.py
+++ b/python/HEPCNN/torch_model_circpad.py
@@ -1,17 +1,17 @@
 import torch
 import torch.nn as nn
 
-class CircularPadY(nn.Module):
+class CircularPadX(nn.Module):
     def __init__(self, pad):
-        super(CircularPadY, self).__init__()
+        super(CircularPadX, self).__init__()
         self.pad = pad
 
     def forward(self, x):
         ## Note: attaching left&right column does the same with append 2 columns on the right hand side
         if x.dim() == 4:
-            return torch.cat([x, x[:,:,-2*self.pad:,:]], dim=-2)
+            return torch.cat([x, x[:,:,:,-2*self.pad:]], dim=-2)
         elif x.dim() == 3:
-            return torch.cat([x, x[:,-2*self.pad:,:]], dim=-2)
+            return torch.cat([x, x[:,:,-2*self.pad:]], dim=-2)
         return None
 
 class MyModel(nn.Module):
@@ -26,8 +26,8 @@ class MyModel(nn.Module):
         self.conv = []
 
         self.conv.extend([
-            CircularPadY(1),
-            nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=(0,1)), ## padding=(height,width)
+            CircularPadX(1),
+            nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=(1,0)), ## padding=(height,width)
 
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
@@ -38,8 +38,8 @@ class MyModel(nn.Module):
         self.fw = self.fw//2
 
         self.conv.extend([
-            CircularPadY(1),
-            nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=(0,1)),
+            CircularPadX(1),
+            nn.Conv2d(64, 128, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
@@ -50,8 +50,8 @@ class MyModel(nn.Module):
         self.fw = self.fw//2
 
         self.conv.extend([
-            CircularPadY(1),
-            nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=(0,1)),
+            CircularPadX(1),
+            nn.Conv2d(128, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
             nn.MaxPool2d(kernel_size=(2, 2)),
             nn.ReLU(),
@@ -63,8 +63,8 @@ class MyModel(nn.Module):
         self.fw = self.fw//2
 
         self.conv.extend([
-            CircularPadY(1),
-            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=(0,1)),
+            CircularPadX(1),
+            nn.Conv2d(256, 256, kernel_size=(3, 3), stride=1, padding=(1,0)),
 
             nn.ReLU(),
             nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),

--- a/python/HEPCNN/torch_model_default.py
+++ b/python/HEPCNN/torch_model_default.py
@@ -38,9 +38,9 @@ class MyModel(nn.Module):
         self.fc = nn.Sequential(
             nn.Linear(self.fw*self.fh*256, 512),
             nn.ReLU(),
-            nn.Dropout2d(0.5),
+            nn.Dropout(0.5),
             nn.Linear(512, 1),
-            nn.Sigmoid(),
+            #nn.Sigmoid(),
         )
 
     def forward(self, x):

--- a/python/HEPCNN/torch_model_original.py
+++ b/python/HEPCNN/torch_model_original.py
@@ -46,9 +46,9 @@ class MyModel(nn.Module):
         self.fc = nn.Sequential(
             nn.Linear(self.fw*self.fh*256, 512),
             nn.ReLU(),
-            nn.Dropout2d(0.5),
+            nn.Dropout(0.5),
             nn.Linear(512, 1),
-            nn.Sigmoid(),
+            #nn.Sigmoid(),
         )
 
     def forward(self, x):

--- a/run/drawLossCurve.py
+++ b/run/drawLossCurve.py
@@ -6,14 +6,22 @@ import sys, os
 plt.rcParams['lines.linewidth'] = 1
 plt.rcParams['lines.markersize'] = 5
 plt.rcParams["legend.loc"] = 'upper right'
+plt.rcParams["legend.frameon"] = False
+plt.rcParams["legend.loc"] = 'upper left'
 
-plt.rcParams['figure.figsize'] = (4*3, 3.5*2)
-ax1 = plt.subplot(2, 3, 1, yscale='log', ylabel='Loss(train)', xlabel='epoch')
-ax2 = plt.subplot(2, 3, 2, yscale='log', ylabel='Loss(val)', xlabel='epoch')
-#ax1 = plt.subplot(2, 3, 1, ylabel='Loss(train)')
-#ax2 = plt.subplot(2, 3, 2, ylabel='Loss(val)')
-ax3 = plt.subplot(2, 3, 4, ylabel='Accuracy(train)', xlabel='epoch')
-ax4 = plt.subplot(2, 3, 5, ylabel='Accuracy(val)', xlabel='epoch')
+plt.rcParams['figure.figsize'] = (4*2, 3.5*3)
+ax1 = plt.subplot(3, 2, 1, yscale='log', ylabel='Loss(train)', xlabel='epoch')
+ax2 = plt.subplot(3, 2, 2, yscale='log', ylabel='Loss(val)', xlabel='epoch')
+ax3 = plt.subplot(3, 2, 3, ylabel='Accuracy(train)', xlabel='epoch')
+ax4 = plt.subplot(3, 2, 4, ylabel='Accuracy(val)', xlabel='epoch')
+ax1.set_ylim([3e-2,2e-1])
+ax2.set_ylim([3e-2,2e-1])
+ax3.set_ylim([0.85,1])
+ax4.set_ylim([0.85,1])
+for ax in (ax1, ax2, ax3, ax4):
+    ax.grid(which='major', axis='both', linestyle='-.')
+    ax.grid(which='minor', linestyle=':')
+    ax.set_xlim([0,50])
 lines, labels = [], []
 for d in sys.argv[1:]:
     df = pd.read_csv(d)
@@ -25,14 +33,14 @@ for d in sys.argv[1:]:
 
     ax3.plot(df['acc'], '.-', label=label)
     ax4.plot(df['val_acc'], '.-', label=label)
-    #ax.set_ylim([0,1])
 
     lines.append(l[0])
     labels.append(label)
 
-ax5 = plt.subplot(1,3,3)
+ax5 = plt.subplot(3,1,3)
 ax5.legend(lines, labels)
 ax5.axis('off')
 
 plt.tight_layout()
 plt.show()
+

--- a/run/train_torch.py
+++ b/run/train_torch.py
@@ -181,7 +181,7 @@ try:
             weight = weight.float().to(device)
 
             pred = model(data)
-            crit = torch.nn.BCELoss(weight=weight)
+            crit = torch.nn.BCEWithLogitsLoss(weight=weight)
             if device == 'cuda': crit = crit.cuda()
             l = crit(pred.view(-1), label)
             l.backward()
@@ -204,7 +204,7 @@ try:
             weight = weight.float().to(device)
 
             pred = model(data)
-            crit = torch.nn.BCELoss(weight=weight)
+            crit = torch.nn.BCEWithLogitsLoss(weight=weight)
             loss = crit(pred.view(-1), label)
 
             val_loss += loss.item()


### PR DESCRIPTION
(edit: NHWC->NCHW done with dataset, NCHW=(batch,channel,eta,phi) checked by seunghwan)

- Switch to user-defined CP module.
- the input image (phi,eta) maps to (x,y): NCHW->batch,detector,eta,phi
- Default Dropout for the fully connected layers
- Use BCEWithLogitsLoss which is known to be numerically stable.

NOTE: Replication2d padding is not the CP, What we need is [1,2,3,4] -> [1,2,3,4,1,2...] but the RP gives [1,2,3,4] -> [1,...1,1,2,3,4,4...4]