### PR TITLE
Preprocessor upgrade

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -12,7 +12,6 @@ parser.add_argument('-o', '--output', action='store', type=str, help='output fil
 parser.add_argument('-n', '--nevent', action='store', type=int, default=-1, help='number of events to preprocess')
 parser.add_argument('--suffix', action='store', type=str, default='', help='suffix for output ("" for train, "val" for validation set)')
 parser.add_argument('--format', action='store', choices=('NHWC', 'NCHW'), default='NHWC', help='image format for output (NHWC for TF default, NCHW for pytorch default)')
-parser.add_argument('--circpad', action='store', type=int, default=0, help='padding size for the circular padding (0 for no-padding)')
 parser.add_argument('-c', '--chunk', action='store', type=int, default=1024, help='chunk size')
 parser.add_argument('--nocompress', dest='nocompress', action='store_true', default=False, help='disable gzip compression')
 parser.add_argument('-s', '--split', action='store_true', default=False, help='split output file')
@@ -45,19 +44,6 @@ for i, begin in enumerate(range(0, nEventsTotal, args.nevent)):
     #print("Normalizing EM, track histograms...")
     image_e /= image_e.max()
     image_t /= image_t.max()
-
-    if args.circpad > 0:
-        if i == 0:
-            print("Apply circular padding, size=", args.circpad, "...")
-            print("  Note for the next step: circular padding size depend on the CNN structure (layers, kernel, maxpool...).")
-            print("  Please double check with your model.")
-
-            print("    input image shape=", image_h.shape)
-        image_h = np.concatenate([image_h, image_h[:,:,:args.circpad]], axis=-1)
-        image_e = np.concatenate([image_e, image_e[:,:,:args.circpad]], axis=-1)
-        image_t = np.concatenate([image_t, image_t[:,:,:args.circpad]], axis=-1)
-        if i == 0:
-            print("    output image shape=", image_h.shape)
 
     if i == 0:
         print("Joining channels...")

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -85,24 +85,3 @@ for i, begin in enumerate(range(0, nEventsTotal, args.nevent)):
         }
         np.savez_compressed(outFileName, **args)
         print("  done")
-    elif outFileName.endswith('.tfrecords'):
-        import tensorflow as tf
-        options = tf.python_io.TFRecordOptions(
-            compression_method=tf.python_io.TFRecordCompressionType.GZIP,
-            compression_level=9,
-        )
-        with tf.python_io.TFRecordWriter(outFileName, options=options) as writer:
-            nsplit = int(np.ceil(1.0*nEvent/chunkSize))
-            ximage = np.array_split(image, nsplit)
-            xlabels = np.array_split(labels, nsplit)
-            xweights = np.array_split(weights, nsplit)
-            for i in range(nsplit):
-                print("  Write chunk (%d/%d)" % (i, nsplit), end='\r')
-                sys.stdout.flush()
-                ex = tf.train.Example(features=tf.train.Features(feature={
-                    'all_events/images': tf.train.Feature(bytes_list=tf.train.BytesList(value=[ximage[i].tobytes()])),
-                    'all_events/labels': tf.train.Feature(int64_list=tf.train.Int64List(value=xlabels[i].astype(np.int32))),
-                    'all_events/weights': tf.train.Feature(float_list=tf.train.FloatList(value=xweights[i].astype(np.float32))),
-                }))
-                writer.write(ex.SerializeToString())
-            print("\n  done")

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -77,11 +77,3 @@ for i, begin in enumerate(range(0, nEventsTotal, args.nevent)):
             print("  created", outFileName)
             print("  keys=", list(outFile.keys()))
             print("  shape=", outFile['all_events']['images'].shape)
-    elif outFileName.endswith('npz'):
-        args = {
-            'images': image,
-            'labels': labels,
-            'weights': weights,
-        }
-        np.savez_compressed(outFileName, **args)
-        print("  done")

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -114,9 +114,7 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
 
             iOutFile += 1
             outFileName = outPrefix + (("_%d" % iOutFile) if args.split else "") + ".h5"
-            print("Writing output file %s..." % outFileName)
-
-            print(out_image.shape, out_labels.shape, out_weights.shape)
+            print("Writing output file %s..." % outFileName, end='')
 
             chunkSize = min(args.chunk, out_weights.shape[0])
             with h5py.File(outFileName, 'w', libver='latest') as outFile:
@@ -129,9 +127,9 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
                 print("  done")
 
             with h5py.File(outFileName, 'r') as outFile:
-                print("  created", outFileName)
-                print("  keys=", list(outFile.keys()))
-                print("  shape=", outFile['all_events']['images'].shape)
+                print("  created", outFileName, end='')
+                print("  keys=", list(outFile.keys()), end='')
+                print("  shape=", outFile['all_events']['images'].shape, end='')
 
             continue
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -129,7 +129,7 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
             with h5py.File(outFileName, 'r') as outFile:
                 print("  created", outFileName, end='')
                 print("  keys=", list(outFile.keys()), end='')
-                print("  shape=", outFile['all_events']['images'].shape, end='')
+                print("  shape=", outFile['all_events']['images'].shape)
 
             continue
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -63,17 +63,16 @@ for i, begin in enumerate(range(0, nEventsTotal, args.nevent)):
     print("Writing output file %s..." % outFileName)
     nEvent = image.shape[0]
     chunkSize = min(args.chunk, nEvent)
-    if outFileName.endswith('.h5'):
-        with h5py.File(outFileName, 'w', libver='latest') as outFile:
-            g = outFile.create_group('all_events')
-            kwargs = {} if args.nocompress else {'compression':'gzip', 'compression_opts':9}
-            g.create_dataset('images', data=image, chunks=((chunkSize,)+image.shape[1:]), **kwargs)
-            g.create_dataset('labels', data=labels, chunks=(chunkSize,))
-            g.create_dataset('weights', data=weights, chunks=(chunkSize,))
-            outFile.swmr_mode = True
-            print("  done")
+    with h5py.File(outFileName, 'w', libver='latest') as outFile:
+        g = outFile.create_group('all_events')
+        kwargs = {} if args.nocompress else {'compression':'gzip', 'compression_opts':9}
+        g.create_dataset('images', data=image, chunks=((chunkSize,)+image.shape[1:]), **kwargs)
+        g.create_dataset('labels', data=labels, chunks=(chunkSize,))
+        g.create_dataset('weights', data=weights, chunks=(chunkSize,))
+        outFile.swmr_mode = True
+        print("  done")
 
-        with h5py.File(outFileName, 'r') as outFile:
-            print("  created", outFileName)
-            print("  keys=", list(outFile.keys()))
-            print("  shape=", outFile['all_events']['images'].shape)
+    with h5py.File(outFileName, 'r') as outFile:
+        print("  created", outFileName)
+        print("  keys=", list(outFile.keys()))
+        print("  shape=", outFile['all_events']['images'].shape)


### PR DESCRIPTION
Preprocessor upgrades
- Read multiple files, split by number of files
- Dummy label (=1) if not available
- Different input arguments (to account multiple input files)
- Remove unused codes to store in tfrecord, np, npz
- Remove circular padding in this script (we do the CP during the training step)