### PR TITLE
Dataset class with user defined label

### DIFF
--- a/python/HEPCNN/dataset_hepcnn.py
+++ b/python/HEPCNN/dataset_hepcnn.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env pythnon
+import numpy as np
+import h5py
+import torch
+from torch.utils.data import Dataset
+from bisect import bisect_right
+from os import environ
+import concurrent.futures as futures
+from glob import glob
+
+class HEPCNNDataset(Dataset):
+    def __init__(self, **kwargs):
+        super(HEPCNNDataset, self).__init__()
+
+        self.procFiles = {}
+        self.procLabels = {}
+
+        self.maxEventsList = [0,]
+        self.imagesList = []
+        self.labelsList = []
+        self.weightsList = []
+        self.rescaleList = []
+        self.cache_fileIdx = -1
+
+    def __getitem__(self, idx):
+        fileIdx = bisect_right(self.maxEventsList, idx)-1
+        offset = self.maxEventsList[fileIdx]
+
+        if self.cache_fileIdx != fileIdx:
+            self.cache_fileIdx = fileIdx
+
+            self.cache_images  = self.imagesList[fileIdx]
+            self.cache_labels  = self.labelsList[fileIdx]
+            self.cache_weights = self.weightsList[fileIdx]
+            self.cache_rescale = self.rescaleList[fileIdx]
+
+        idx = idx - offset
+        return (self.cache_images[idx], self.cache_labels[idx], self.cache_weights[idx], self.cache_rescale[idx])
+
+    def __len__(self):
+        return self.maxEventsList[-1]
+
+    def addSample(self, procName, fileNames, weight=None, logger=None):
+        if logger: logger.update(annotation='Add sample %s <= %s' % (procName, fileNames))
+        weightValue = weight ## Rename it just to be clear in the codes
+
+        if procName not in self.procFiles:
+            self.procFiles[procName] = [] ## this list keeps image index - later we will use this info to get total event and update weights, etc
+
+        for fileName in glob(fileNames):
+            data = h5py.File(fileName, 'r')['all_events']
+            suffix = "_val" if 'images_val' in data else ""
+
+            images  = (fileName, 'images'+suffix) ## Keep the filename and image path only, and load them later with multiproc.
+            weights = data['weights'+suffix]
+            size = weights.shape[0]
+
+            if weightValue is None: weights = data['weights'+suffix]
+            else: weights = torch.ones(size)*weightValue
+
+            nEventsInFile = len(weights)
+            self.maxEventsList.append(nEventsInFile)
+
+            labels  = torch.zeros(size) ## Put dummy labels, to set later by calling setProcessLabel()
+            weights = torch.Tensor(weights[()])
+            ## We will do this step for images later
+
+            fileIdx = len(self.imagesList)
+            self.procFiles[procName].append(fileIdx)
+            self.imagesList.append(images)
+            self.labelsList.append(labels)
+            self.weightsList.append(weights)
+            self.rescaleList.append(torch.ones(size))
+
+    def setProcessLabel(self, procName, label):
+        for i in self.procFiles[procName]:
+            size = self.labelsList[i].shape[0]
+            self.labelsList[i] = torch.ones(size)*label
+            self.procLabels[procName] = label
+
+    def imageToTensor(self, fileIdx):
+        fileName, imagesName = self.imagesList[fileIdx]
+        data = h5py.File(fileName, 'r')['all_events']
+        images = data[imagesName]
+        t = torch.Tensor(images[()])
+        data = None
+        return fileIdx, t
+
+    def initialize(self, nWorkers=1, logger=None):
+        if logger: logger.update(annotation='Reweights by category imbalance')
+        ## Compute sum of weights for each label categories
+        sumWByLabel = {}
+        sumEByLabel = {}
+        for procName, fileIdxs in self.procFiles.items():
+            label = self.procLabels[procName]
+            if label not in sumWByLabel: sumWByLabel[label] = 0.
+            if label not in sumEByLabel: sumEByLabel[label] = 0.
+            procSumW = sum([sum(self.weightsList[i]) for i in fileIdxs])
+            procSumE = sum([len(self.weightsList[i]) for i in fileIdxs])
+            print("@@@ Process=%s nEvent=%d sumW=%.3f events/fb-1" % (procName, procSumE, procSumW.item()))
+            sumWByLabel[label] += procSumW
+            sumEByLabel[label] += procSumE
+
+        ## Find rescale factors - make average weight to be 1 for each cat in the training step
+        for procName, fileIdxs in self.procFiles.items():
+            label = self.procLabels[procName]
+            for i in fileIdxs: self.rescaleList[i] *= sumEByLabel[label]/sumWByLabel[label]
+
+        if logger: logger.update(annotation='Convert images to Tensor')
+
+        env_kmp = environ['KMP_AFFINITY'] if 'KMP_AFFINITY' in environ else None
+        environ['KMP_AFFINITY'] = 'none'
+        jobs = []
+        with futures.ProcessPoolExecutor(max_workers=nWorkers) as pool:
+            for fileIdx in range(len(self.maxEventsList)-1):
+                job = pool.submit(self.imageToTensor, fileIdx)
+                jobs.append(job)
+
+            for job in futures.as_completed(jobs):
+                fileIdx, images = job.result()
+                self.imagesList[fileIdx] = images
+        if env_kmp != None: environ['KMP_AFFINITY'] = env_kmp
+
+        for fileIdx in range(len(self.maxEventsList)-1):
+            #images  = torch.Tensor(self.imagesList[fileIdx][()])
+            images = self.imagesList[fileIdx]
+            self.shape = images.shape
+
+            if self.shape[-1] <= 5:
+                ## actual format was NHWC. convert to pytorch native format, NCHW
+                images = images.permute(0,3,1,2)
+                self.shape = images.shape
+                if logger: logger.update(annotation="Convert image format")
+
+            self.imagesList[fileIdx] = images
+            self.channel, self.height, self.width = self.shape[1:]
+

--- a/python/HEPCNN/dataset_hepcnn.py
+++ b/python/HEPCNN/dataset_hepcnn.py
@@ -108,6 +108,7 @@ class HEPCNNDataset(Dataset):
             label = self.procLabels[procName]
             if label == maxSumELabel: continue
             sf = sumEByLabel[maxSumELabel]/sumEByLabel[label]
+            print("@@@ Scale up the sample", label, "->", maxSumELabel, sf)
             for i in fileIdxs: self.rescaleList[i] *= sf
 
         if logger: logger.update(annotation='Convert images to Tensor')

--- a/python/HEPCNN/dataset_hepcnn.py
+++ b/python/HEPCNN/dataset_hepcnn.py
@@ -59,7 +59,7 @@ class HEPCNNDataset(Dataset):
             else: weights = torch.ones(size)*weightValue
 
             nEventsInFile = len(weights)
-            self.maxEventsList.append(nEventsInFile)
+            self.maxEventsList.append(self.maxEventsList[-1]+nEventsInFile)
 
             labels  = torch.zeros(size) ## Put dummy labels, to set later by calling setProcessLabel()
             weights = torch.Tensor(weights[()])

--- a/python/HEPCNN/dataset_hepcnn.py
+++ b/python/HEPCNN/dataset_hepcnn.py
@@ -102,6 +102,13 @@ class HEPCNNDataset(Dataset):
         for procName, fileIdxs in self.procFiles.items():
             label = self.procLabels[procName]
             for i in fileIdxs: self.rescaleList[i] *= sumEByLabel[label]/sumWByLabel[label]
+        ## Find overall rescale for the data imbalancing problem - fit to the category with maximum entries
+        maxSumELabel = max(sumEByLabel, key=lambda key: sumEByLabel[key])
+        for procName, fileIdxs in self.procFiles.items():
+            label = self.procLabels[procName]
+            if label == maxSumELabel: continue
+            sf = sumEByLabel[maxSumELabel]/sumEByLabel[label]
+            for i in fileIdxs: self.rescaleList[i] *= sf
 
         if logger: logger.update(annotation='Convert images to Tensor')
 

--- a/run/eval_torch.py
+++ b/run/eval_torch.py
@@ -15,7 +15,6 @@ torch.set_num_threads(nthreads)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--batch', action='store', type=int, default=256, help='Batch size')
-parser.add_argument('-t', '--test', action='store', type=str, required=True, help='Test dataset')
 parser.add_argument('-d', '--input', action='store', type=str, required=True, help='directory with pretrained model parameters')
 parser.add_argument('--model', action='store', choices=('default', 'log3ch', 'log5ch', 'original', 'circpad', 'circpadlog3ch', 'circpadlog5ch'),
                                default='default', help='choice of model')
@@ -28,17 +27,34 @@ import pandas as pd
 if not os.path.exists(predFile):
     sys.path.append("../python")
 
-    from HEPCNN.torch_dataset_splited import HEPCNNSplitDataset as MySplitDataset
-    from HEPCNN.torch_dataset import HEPCNNDataset as MyDataset
+    print("Load data", end='')
+    from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
-    kwargs = {'num_workers':min(4, nthreads), 'pin_memory':True}
+    myDataset = MyDataset()
+    myDataset.addSample("RPV_1400", "../data/CMS2018_unmerged/RPV/Gluino1400GeV/*/*.h5", weight=0.013/330599)
+    #myDataset.addSample("QCD_HT700to1000" , "../data/CMS2018_unmerged/QCD/HT700to1000/*/*.h5", weight=???)
+    #myDataset.addSample("QCD_HT1000to1500", "../data/CMS2018_unmerged/QCD/HT1000to1500/*/*.h5", weight=1094./15466225)
+    myDataset.addSample("QCD_HT1500to2000", "../data/CMS2018_unmerged/QCD/HT1500to2000/*/*.h5", weight=99.16/3199737)
+    myDataset.addSample("QCD_HT2000toInf" , "../data/CMS2018_unmerged/QCD/HT2000toInf/*/*.h5", weight=20.25/1520178)
+    myDataset.setProcessLabel("RPV_1400", 1)
+    myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
+    myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
+    myDataset.initialize(nWorkers=10)
+    print("done")
 
-    if os.path.isdir(args.test):
-        testDataset = MySplitDataset(args.test, nWorkers=nthreads//2)
-    else:
-        testDataset = MyDataset(args.test)
+    print("Split data", end='')
+    lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
+    lengths.append(len(myDataset)-sum(lengths))
+    torch.manual_seed(123456)
+    trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)
+    torch.manual_seed(torch.initial_seed())
+    print("done")
+
+    kwargs = {'num_workers':min(4, nthreads)}#, 'pin_memory':True}
+
     testLoader = DataLoader(testDataset, batch_size=args.batch, shuffle=False, **kwargs)
 
+    print("Load model", end='')
     if os.path.exists(args.input+'/model.pkl'):
         print("Load saved model from", (args.input+'/model.pkl'))
         model = torch.load(args.input+'/model.pkl')
@@ -56,20 +72,25 @@ if not os.path.exists(predFile):
     if torch.cuda.is_available():
         model = model.cuda()
         device = 'cuda'
+    print('done')
+
+    model.load_state_dict(torch.load(args.input+'/weight_0.pkl'))
+    print('modify model', end='')
+    model.fc.add_module('output', torch.nn.Sigmoid())
+    model.eval()
+    print('done')
 
     from tqdm import tqdm
-    model.load_state_dict(torch.load(args.input+'/weight_0.pkl'))
-    model.eval()
-
-    labels, preds = [], []
-    for i, (data, label, weight) in enumerate(tqdm(testLoader)):
+    labels, weights, preds = [], [], []
+    for i, (data, label, weight, rescale) in enumerate(tqdm(testLoader)):
         data = data.float().to(device)
         weight = weight.float()
         pred = model(data).detach().to('cpu').float()
 
         labels.extend([x.item() for x in label])
         preds.extend([x.item() for x in pred.view(-1)])
-    df = pd.DataFrame({'label':labels, 'prediction':preds})
+        weights.extend([x.item() for x in (weight*rescale).view(-1)])
+    df = pd.DataFrame({'label':labels, 'weight':weights, 'prediction':preds})
     df.to_csv(predFile, index=False)
 
 from sklearn.metrics import roc_curve, roc_auc_score
@@ -78,10 +99,18 @@ tpr, fpr, thr = roc_curve(df['label'], df['prediction'], pos_label=0)
 auc = roc_auc_score(df['label'], df['prediction'])
 
 import matplotlib.pyplot as plt
-plt.plot(fpr, tpr, label='%s %.3f' % (args.input, auc))
+print(df.keys())
+df[df.label==0]['prediction'].hist(bins=100, alpha=0.7, color='red')
+df[df.label==1]['prediction'].hist(bins=100, alpha=0.7, color='blue')
+plt.yscale('log')
+plt.show()
+
+plt.plot(fpr, tpr, '.-', label='%s %.3f' % (args.input, auc))
 plt.xlabel('False Positive Rate')
 plt.ylabel('True Positive Rate')
-plt.xlim(0, 0.001)
+#plt.xlim(0, 0.001)
+plt.xlim(0, 1.000)
 plt.ylim(0, 1.000)
 plt.legend()
 plt.show()
+

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+import h5py
+import numpy as np
+import argparse
+import sys, os
+import subprocess
+import csv
+import math
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+
+try:
+    import horovod.torch as hvd
+except:
+    hvd = None
+
+nthreads = int(os.popen('nproc').read()) ## nproc takes allowed # of processes. Returns OMP_NUM_THREADS if set
+print("NTHREADS=", nthreads, "CPU_COUNT=", os.cpu_count())
+torch.set_num_threads(nthreads)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--epoch', action='store', type=int, default=50, help='Number of epochs')
+parser.add_argument('--batch', action='store', type=int, default=256, help='Batch size')
+parser.add_argument('-o', '--outdir', action='store', type=str, required=True, help='Path to output directory')
+parser.add_argument('--lr', action='store', type=float, default=1e-3, help='Learning rate')
+parser.add_argument('--batchPerStep', action='store', type=int, default=1, help='Number of batches per step (to emulate all-reduce)')
+parser.add_argument('--shuffle', action='store', type=bool, default=True, help='Shuffle batches for each epochs')
+parser.add_argument('--optimizer', action='store', choices=('sgd', 'adam', 'radam', 'ranger'), default='adam', help='optimizer to run')
+parser.add_argument('--model', action='store', choices=('default', 'log3ch', 'log5ch', 'original', 'circpad', 'circpadlog3ch', 'circpadlog5ch'), 
+                               default='default', help='choice of model')
+parser.add_argument('--nreader', action='store', type=int, default=1, help='Number of loaders')
+
+args = parser.parse_args()
+
+hvd_rank, hvd_size = 0, 1
+if hvd:
+    hvd.init()
+    hvd_rank = hvd.rank()
+    hvd_size = hvd.size()
+    print("Horovod is available. (rank=%d size=%d)" % (hvd_rank, hvd_size))
+    #torch.manual_seed(args.seed)
+    #torch.cuda.set_device(hvd.local_rank())
+
+if not os.path.exists(args.outdir): os.makedirs(args.outdir)
+modelFile = os.path.join(args.outdir, 'model.pkl')
+weightFile = os.path.join(args.outdir, 'weight_%d.pkl' % hvd_rank)
+predFile = os.path.join(args.outdir, 'predict_%d.npy' % hvd_rank)
+trainingFile = os.path.join(args.outdir, 'history_%d.csv' % hvd_rank)
+resourceByCPFile = os.path.join(args.outdir, 'resourceByCP_%d.csv' % hvd_rank)
+resourceByTimeFile = os.path.join(args.outdir, 'resourceByTime_%d.csv' % hvd_rank)
+
+proc = subprocess.Popen(['python', '../scripts/monitor_proc.py', '-t', '1',
+                        '-o', resourceByTimeFile, '%d' % os.getpid()],
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+import time
+class TimeHistory():#tf.keras.callbacks.Callback):
+    def on_train_begin(self):
+        self.times = []
+    def on_epoch_begin(self):
+        self.epoch_time_start = time.time()
+    def on_epoch_end(self):
+        self.times.append(time.time() - self.epoch_time_start)
+
+sys.path.append("../scripts")
+from monitor_proc import SysStat
+sysstat = SysStat(os.getpid(), fileName=resourceByCPFile)
+sysstat.update(annotation="start_loggin")
+
+sys.path.append("../python")
+from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
+
+myDataset = MyDataset()
+myDataset.addSample("RPV_1400", "../data/CMS2018_unmerged/RPV/Gluino1400GeV/*/*.h5", weight=0.013/330599)
+#myDataset.addSample("QCD_HT700to1000" , "../data/CMS2018_unmerged/QCD/HT700to1000/*/*.h5", weight=???)
+#myDataset.addSample("QCD_HT1000to1500", "../data/CMS2018_unmerged/QCD/HT1000to1500/*/*.h5", weight=1094./15466225)
+myDataset.addSample("QCD_HT1500to2000", "../data/CMS2018_unmerged/QCD/HT1500to2000/*/*.h5", weight=99.16/3199737)
+myDataset.addSample("QCD_HT2000toInf" , "../data/CMS2018_unmerged/QCD/HT2000toInf/*/*.h5", weight=20.25/1520178)
+myDataset.setProcessLabel("RPV_1400", 1)
+myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
+myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
+myDataset.initialize(nWorkers=args.nreader)
+
+lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
+lengths.append(len(myDataset)-sum(lengths))
+trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)
+
+kwargs = {'num_workers':min(4, nthreads)}
+#kwargs = {'num_workers':nthreads}
+#if torch.cuda.is_available() and hvd:
+#    kwargs['num_workers'] = 1
+kwargs['pin_memory'] = True
+
+if hvd:
+    trnSampler = torch.utils.data.distributed.DistributedSampler(trnDataset, num_replicas=hvd_size, rank=hvd_rank)
+    valSampler = torch.utils.data.distributed.DistributedSampler(valDataset, num_replicas=hvd_size, rank=hvd_rank)
+    trnLoader = DataLoader(trnDataset, batch_size=args.batch, sampler=trnSampler, **kwargs)
+    valLoader = DataLoader(valDataset, batch_size=args.batch, sampler=valSampler, **kwargs)
+else:
+    trnLoader = DataLoader(trnDataset, batch_size=args.batch, shuffle=args.shuffle, **kwargs)
+    #valLoader = DataLoader(valDataset, batch_size=args.batch, shuffle=args.shuffle, **kwargs)
+    valLoader = DataLoader(valDataset, batch_size=512, shuffle=False, **kwargs)
+
+## Build model
+if args.model == 'original':
+    from HEPCNN.torch_model_original import MyModel
+elif 'circpad' in args.model:
+    from HEPCNN.torch_model_circpad import MyModel
+else:
+    from HEPCNN.torch_model_default import MyModel
+model = MyModel(myDataset.width, myDataset.height, model=args.model)
+if hvd_rank == 0: torch.save(model, modelFile)
+device = 'cpu'
+if torch.cuda.is_available():
+    model = model.cuda()
+    device = 'cuda'
+
+if args.optimizer == 'radam':
+    from optimizers.RAdam import RAdam
+    optm = RAdam(model.parameters(), lr=args.lr)
+elif args.optimizer == 'ranger':
+    from optimizers.RAdam import RAdam
+    from optimizers.Lookahead import Lookahead
+    optm_base = RAdam(model.parameters(), lr=args.lr)
+    optm = Lookahead(optm_base)
+elif args.optimizer == 'adam':
+    optm = optim.Adam(model.parameters(), lr=args.lr)
+elif args.optimizer == 'sgd':
+    optm = optim.SGD(model.parameters(), lr=args.lr)
+else:
+    print("Cannot find optimizer in the list")
+    exit()
+
+if hvd:
+    compression = hvd.Compression.none
+    #compression = hvd.Compression.fp16 #if args.fp16_allreduce else hvd.Compression.none
+    optm = hvd.DistributedOptimizer(optm,
+                                    named_parameters=model.named_parameters(),
+                                    compression=compression, backward_passes_per_step=args.batch)
+    hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+    hvd.broadcast_optimizer_state(optm, root_rank=0)
+
+def metric_average(val, name):
+    tensor = torch.tensor(val)
+    avg_tensor = hvd.allreduce(tensor, name=name)
+    return avg_tensor.item()
+
+sysstat.update(annotation="modelsetup_done")
+
+with open(args.outdir+'/summary.txt', 'w') as fout:
+    fout.write(str(args))
+    fout.write('\n\n')
+    fout.write(str(model))
+    fout.close()
+
+from tqdm import tqdm
+from sklearn.metrics import accuracy_score
+bestModel, bestAcc = {}, -1
+try:
+    timeHistory = TimeHistory()
+    timeHistory.on_train_begin()
+    sysstat.update(annotation="train_start")
+    history = {'time':[], 'loss':[], 'acc':[], 'val_loss':[], 'val_acc':[]}
+
+    for epoch in range(args.epoch):
+        timeHistory.on_epoch_begin()
+        sysstat.update(annotation='epoch_begin')
+
+        model.train()
+        trn_loss, trn_acc = 0., 0.
+        optm.zero_grad()
+        for i, (data, label, weight, rescale) in enumerate(tqdm(trnLoader, desc='epoch %d/%d' % (epoch+1, args.epoch))):
+            data = data.float().to(device)
+            label = label.float().to(device)
+            rescale = rescale.float().to(device)
+            weight = weight.float().to(device)*rescale
+
+            pred = model(data)
+            crit = torch.nn.BCEWithLogitsLoss(weight=weight)
+            if device == 'cuda': crit = crit.cuda()
+            l = crit(pred.view(-1), label)
+            l.backward()
+            if i % args.batchPerStep == 0 or i+1 == len(trnLoader):
+                optm.step()
+                optm.zero_grad()
+
+            trn_loss += l.item()
+            trn_acc += accuracy_score(label.to('cpu'), np.where(pred.to('cpu') > 0.5, 1, 0))
+
+            sysstat.update()
+        trn_loss /= len(trnLoader)
+        trn_acc  /= len(trnLoader)
+
+        model.eval()
+        val_loss, val_acc = 0., 0.
+        for i, (data, label, weight, rescale) in enumerate(tqdm(valLoader)):
+            data = data.float().to(device)
+            label = label.float().to(device)
+            rescale = rescale.float().to(device)
+            weight = weight.float().to(device)*rescale
+
+            pred = model(data)
+            crit = torch.nn.BCEWithLogitsLoss(weight=weight)
+            loss = crit(pred.view(-1), label)
+
+            val_loss += loss.item()
+            val_acc += accuracy_score(label.to('cpu'), np.where(pred.to('cpu') > 0.5, 1, 0))
+        val_loss /= len(valLoader)
+        val_acc  /= len(valLoader)
+
+        if hvd: val_acc = metric_average(val_acc, 'avg_accuracy')
+        if bestAcc < val_acc:
+            bestModel = model.state_dict()
+            bestAcc = val_acc
+            if hvd_rank == 0:
+                torch.save(bestModel, weightFile)
+                sysstat.update(annotation="saved_model")
+
+        timeHistory.on_epoch_end()
+        sysstat.update(annotation='epoch_end')
+        history['loss'].append(trn_loss)
+        history['acc'].append(trn_acc)
+        history['val_loss'].append(val_loss)
+        history['val_acc'].append(val_acc)
+
+        history['time'].append(timeHistory.times[-1])
+        if hvd_rank == 0:
+            with open(trainingFile, 'w') as f:
+                writer = csv.writer(f)
+                keys = history.keys()
+                writer.writerow(keys)
+                for row in zip(*[history[key] for key in keys]):
+                    writer.writerow(row)
+            sysstat.update(annotation="wrote_logs")
+
+    sysstat.update(annotation="train_end")
+
+except KeyboardInterrupt:
+    print("Training finished early")

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -73,6 +73,7 @@ sysstat.update(annotation="start_loggin")
 sys.path.append("../python")
 from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
+sysstat.update(annotation="add samples")
 myDataset = MyDataset()
 myDataset.addSample("RPV_1400", "../data/CMS2018_unmerged/RPV/Gluino1400GeV/*/*.h5", weight=0.013/330599)
 #myDataset.addSample("QCD_HT700to1000" , "../data/CMS2018_unmerged/QCD/HT700to1000/*/*.h5", weight=???)
@@ -82,8 +83,10 @@ myDataset.addSample("QCD_HT2000toInf" , "../data/CMS2018_unmerged/QCD/HT2000toIn
 myDataset.setProcessLabel("RPV_1400", 1)
 myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
 myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
+sysstat.update(annotation="init dataset")
 myDataset.initialize(nWorkers=args.nreader)
 
+sysstat.update(annotation="split dataset")
 lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
 lengths.append(len(myDataset)-sum(lengths))
 trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)
@@ -105,6 +108,7 @@ else:
     valLoader = DataLoader(valDataset, batch_size=512, shuffle=False, **kwargs)
 
 ## Build model
+sysstat.update(annotation="Model start")
 if args.model == 'original':
     from HEPCNN.torch_model_original import MyModel
 elif 'circpad' in args.model:

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -89,7 +89,9 @@ myDataset.initialize(nWorkers=args.nreader)
 sysstat.update(annotation="split dataset")
 lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
 lengths.append(len(myDataset)-sum(lengths))
+torch.manual_seed(123456)
 trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)
+torch.manual_seed(torch.initial_seed())
 
 kwargs = {'num_workers':min(4, nthreads)}
 #kwargs = {'num_workers':nthreads}

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -75,16 +75,18 @@ from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
 sysstat.update(annotation="add samples")
 myDataset = MyDataset()
-myDataset.addSample("RPV_1400", "../data/CMS2018_unmerged/RPV/Gluino1400GeV/*/*.h5", weight=0.013/330599)
-#myDataset.addSample("QCD_HT700to1000" , "../data/CMS2018_unmerged/QCD/HT700to1000/*/*.h5", weight=???)
-#myDataset.addSample("QCD_HT1000to1500", "../data/CMS2018_unmerged/QCD/HT1000to1500/*/*.h5", weight=1094./15466225)
-myDataset.addSample("QCD_HT1500to2000", "../data/CMS2018_unmerged/QCD/HT1500to2000/*/*.h5", weight=99.16/3199737)
-myDataset.addSample("QCD_HT2000toInf" , "../data/CMS2018_unmerged/QCD/HT2000toInf/*/*.h5", weight=20.25/1520178)
+basedir = "../data/CMS2018_unmerged/hdf5_noPU/"
+myDataset.addSample("RPV_1400", basedir+"RPV/Gluino1400GeV/*.h5", weight=0.013/330599)
+#myDataset.addSample("QCD_HT700to1000" , basedir+"QCD/HT700to1000/*/*.h5", weight=???)
+myDataset.addSample("QCD_HT1000to1500", basedir+"QCDBkg/HT1000to1500/*.h5", weight=1094./15466225)
+myDataset.addSample("QCD_HT1500to2000", basedir+"QCDBkg/HT1500to2000/*.h5", weight=99.16/3199737)
+myDataset.addSample("QCD_HT2000toInf" , basedir+"QCDBkg/HT2000toInf/*.h5", weight=20.25/1520178)
 myDataset.setProcessLabel("RPV_1400", 1)
+myDataset.setProcessLabel("QCD_HT1000to1500", 0) ## This is not necessary because the default is 0
 myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
 myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
 sysstat.update(annotation="init dataset")
-myDataset.initialize(nWorkers=args.nreader)
+myDataset.initialize(nWorkers=args.nreader, logger=sysstat)
 
 sysstat.update(annotation="split dataset")
 lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
@@ -94,10 +96,9 @@ trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, l
 torch.manual_seed(torch.initial_seed())
 
 kwargs = {'num_workers':min(4, nthreads)}
-#kwargs = {'num_workers':nthreads}
-#if torch.cuda.is_available() and hvd:
-#    kwargs['num_workers'] = 1
-kwargs['pin_memory'] = True
+if torch.cuda.is_available():
+    #if hvd: kwargs['num_workers'] = 1
+    kwargs['pin_memory'] = True
 
 if hvd:
     trnSampler = torch.utils.data.distributed.DistributedSampler(trnDataset, num_replicas=hvd_size, rank=hvd_rank)


### PR DESCRIPTION
미리 여러 데이터셋을 섞고 weight를 계산해 데이터에 저장 후 train, validation, test set으로 구분하는 기존의 방법에서 비효율성이 있습니다.
이 PR에서는 데이터 파일 내에 label이나 weight 자체를 저장하는 대신 user가 직접 training 스크립트에서 지정할 수 있게 합니다. 이는 TMVA와 약간 닮은 면이 있습니다.

예를 들어 다음 코드와 같은 식으로 해서 샘플을 dataset에 추가하고, 동시에 (cross section)/(nGenEvent) 를 세팅해 normalize해줍니다.
Process 이름에 따라 어떤 번호로 label을 줄지 지정할 수 있습니다. Multiclassification을 할 경우에 대비해 addSignal 이나 addBackground등의 함수 형태를 쓰지 않았습니다.

```
myDataset = MyDataset()
myDataset.addSample("RPV_1400", "../data/CMS2018_unmerged/RPV/Gluino1400GeV/*/*.h5", weight=0.013/330599)
#myDataset.addSample("QCD_HT700to1000" , "../data/CMS2018_unmerged/QCD/HT700to1000/*/*.h5", weight=???)
#myDataset.addSample("QCD_HT1000to1500", "../data/CMS2018_unmerged/QCD/HT1000to1500/*/*.h5", weight=1094./15466225)
myDataset.addSample("QCD_HT1500to2000", "../data/CMS2018_unmerged/QCD/HT1500to2000/*/*.h5", weight=99.16/3199737)
myDataset.addSample("QCD_HT2000toInf" , "../data/CMS2018_unmerged/QCD/HT2000toInf/*/*.h5", weight=20.25/1520178)
myDataset.setProcessLabel("RPV_1400", 1)
myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
myDataset.initialize(nWorkers=args.nreader)

lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
lengths.append(len(myDataset)-sum(lengths))
trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)

```

위의 initialize 함수에서 이미지에 대한 텐서로의 변환이나, 전체 rescaling을 위한 sumWeight 계산 등이 이루어집니다.

Training, validation, testing set의 분리는 torch.utils.data.random_split을 이용합니다.

sample imbalance문제 해결을 위한 rescaling은 실제 training과 validation 단계에서 weight에 rescale factor를 직접 곱해주는 방식으로 하게 되는데, 이것은 같은 dataloader를 이용해 test set 그림을 그릴 수 있다고 판단했기 때문입니다.

Related issue: #71 