### PR TITLE
Bugfix Preprocessor + training without preload as tensors

### DIFF
--- a/python/HEPCNN/dataset_hepcnn.py
+++ b/python/HEPCNN/dataset_hepcnn.py
@@ -68,11 +68,6 @@ class HEPCNNDataset(Dataset):
             self.labelsList[i] = torch.ones(size, dtype=torch.float32, requires_grad=False)*label
             self.procLabels[procName] = label
 
-    def imageToTensor(self, fileIdx):
-        fileName, imagesName = self.imagesList[fileIdx]
-        data = h5py.File(fileName, 'r', libver='latest', swmr=True)['all_events']
-        return fileIdx, torch.Tensor(data[imagesName][()])
-
     def initialize(self, logger=None):
         if logger: logger.update(annotation='Reweights by category imbalance')
         ## Compute sum of weights for each label categories

--- a/python/HEPCNN/torch_model_default.py
+++ b/python/HEPCNN/torch_model_default.py
@@ -3,13 +3,16 @@ import torch
 import torch.nn as nn
 
 class MyModel(nn.Module):
-    def __init__(self, width, height, model='default'):
+    def __init__(self, width, height, **kwargs):
         super(MyModel, self).__init__()
+        model = "default" if "model" not in kwargs else kwargs["model"]
         self.fw = width//2//2//2
         self.fh = height//2//2//2
 
         self.nch = 5 if '5ch' in model else 3
         self.doLog = ('log' in model)
+        self.doNorm = ('norm' in model)
+        self.doNormCat = ('cat' in model)
 
         self.conv = nn.Sequential(
             nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=1),
@@ -36,7 +39,7 @@ class MyModel(nn.Module):
             nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
         )
         self.fc = nn.Sequential(
-            nn.Linear(self.fw*self.fh*256, 512),
+            nn.Linear(self.fw*self.fh*256 + (3 if self.doNormCat else 0), 512),
             nn.ReLU(),
             nn.Dropout(0.5),
             nn.Linear(512, 1),
@@ -44,6 +47,15 @@ class MyModel(nn.Module):
         )
 
     def forward(self, x):
+        n, c = x.shape[0], x.shape[1]
+        if c > 6: ## We don't expect image more than 6 channel, this indicates that the image format was NHWC.
+            x = x.permute(0,3,1,2)
+            c = x.shape[1]
+        s, _ = torch.max(x.view(n,c,-1), dim=-1)
+        if self.doNorm:
+            x[:,0,:,:] /= s[:,0,None,None]
+            x[:,1,:,:] /= s[:,1,None,None]
+            x[:,2,:,:] /= s[:,2,None,None]
         if self.nch == 5:
             xx = x[:,:2,:,:]
             x = torch.cat((x, xx), dim=1)
@@ -51,7 +63,7 @@ class MyModel(nn.Module):
             x[:,:2,:,:] = torch.log10(x[:,:2,:,:]/1e-5+1)
         x = self.conv(x)
         x = x.view(-1, self.fw*self.fh*256)
+        if self.doNormCat: x = torch.cat([x, s], dim=-1)
         x = self.fc(x)
         return x
-
 

--- a/python/HEPCNN/torch_model_default.py
+++ b/python/HEPCNN/torch_model_default.py
@@ -11,8 +11,8 @@ class MyModel(nn.Module):
 
         self.nch = 5 if '5ch' in model else 3
         self.doLog = ('log' in model)
-        self.doNorm = ('norm' in model)
-        self.doNormCat = ('cat' in model)
+        self.doNorm = ('fixed' not in model)
+        self.doCat = ('cat' in model)
 
         self.conv = nn.Sequential(
             nn.Conv2d(self.nch, 64, kernel_size=(3, 3), stride=1, padding=1),
@@ -39,7 +39,7 @@ class MyModel(nn.Module):
             nn.BatchNorm2d(num_features=256, eps=0.001, momentum=0.99),
         )
         self.fc = nn.Sequential(
-            nn.Linear(self.fw*self.fh*256 + (3 if self.doNormCat else 0), 512),
+            nn.Linear(self.fw*self.fh*256 + (3 if self.doCat else 0), 512),
             nn.ReLU(),
             nn.Dropout(0.5),
             nn.Linear(512, 1),
@@ -63,7 +63,7 @@ class MyModel(nn.Module):
             x[:,:2,:,:] = torch.log10(x[:,:2,:,:]/1e-5+1)
         x = self.conv(x)
         x = x.view(-1, self.fw*self.fh*256)
-        if self.doNormCat: x = torch.cat([x, s], dim=-1)
+        if self.doCat: x = torch.cat([x, s], dim=-1)
         x = self.fc(x)
         return x
 

--- a/run/drawPerfHistory.py
+++ b/run/drawPerfHistory.py
@@ -79,7 +79,7 @@ if len(dirs) > 1 or len(metrics) == 1:
     plt.rcParams['figure.figsize'] = (7, len(dirs)*2)
     for metric in metrics:
         for i, d in enumerate(dirs):
-            hostInfo, pars = d.split('/',1)
+            pars = d
             ax = plt.subplot(len(dirs), 1, i+1)
             if maxTime > 0: ax.set_xlim([0, maxTime])
             plt.title(pars.replace('__', ' '))
@@ -109,13 +109,12 @@ if len(metrics) > 1:
     plt.rcParams['figure.figsize'] = (7, len(metrics)*2)
     for j, d in enumerate(dirs):
         for i, metric in enumerate(metrics):
-            hostInfo, pars = d.split('/',1)
             ax = plt.subplot(len(metrics), 1, i+1)
             if maxTime > 0: ax.set_xlim([0, maxTime])
             #ax.set_xlim([0, 3000])
 
             for usage in data[metric][j]:
-                plt.plot(usage['time'], usage[metric], '.-', alpha=0.5)#, label=('rank%d'%ii))#, c=cols[i], label=(pars.replace('__', ' ')))
+                plt.plot(usage['time'], usage[metric], '.-', alpha=0.5)
 
                 if args.annotation:
                     for t, m, s in zip(usage['time'], usage[metric], usage['Annotation']):

--- a/run/eval_torch.py
+++ b/run/eval_torch.py
@@ -32,7 +32,7 @@ if not os.path.exists(predFile):
     from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
     myDataset = MyDataset()
-    basedir = "../data/CMS2018_unmerged/hdf5_noPU/"
+    basedir = "../data/hdf5_noPU_64x64/"
     myDataset.addSample("RPV_1400", basedir+"RPV/Gluino1400GeV/*.h5", weight=0.013/330599)
     #myDataset.addSample("QCD_HT700to1000" , basedir+"QCD/HT700to1000/*/*.h5", weight=???)
     myDataset.addSample("QCD_HT1000to1500", basedir+"QCDBkg/HT1000to1500/*.h5", weight=1094./15466225)
@@ -42,7 +42,7 @@ if not os.path.exists(predFile):
     myDataset.setProcessLabel("QCD_HT1000to1500", 0) ## This is not necessary because the default is 0
     myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
     myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
-    myDataset.initialize(nWorkers=args.nreader)
+    myDataset.initialize()
     print("done")
 
     print("Split data", end='')

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -29,9 +29,9 @@ parser.add_argument('--lr', action='store', type=float, default=1e-3, help='Lear
 parser.add_argument('--batchPerStep', action='store', type=int, default=1, help='Number of batches per step (to emulate all-reduce)')
 parser.add_argument('--shuffle', action='store', type=bool, default=True, help='Shuffle batches for each epochs')
 parser.add_argument('--optimizer', action='store', choices=('sgd', 'adam', 'radam', 'ranger'), default='adam', help='optimizer to run')
-parser.add_argument('--model', action='store', choices=('default', 'defaultnorm', 'defaultnormcat',
-                                                        'log3ch', 'log3chnorm', 'log3chnormcat',
-                                                        'log5ch', 'log5chnorm', 'log5chnormcat',
+parser.add_argument('--model', action='store', choices=('default', 'defaultabs', 'defaultcat',
+                                                        'log3ch', 'log3chabs', 'log3chcat',
+                                                        'log5ch', 'log5chabs', 'log5chcat',
                                                         'original', 
                                                         'circpad', 'circpadlog3ch', 'circpadlog5ch'), 
                                default='default', help='choice of model')
@@ -80,8 +80,7 @@ from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
 sysstat.update(annotation="add samples")
 myDataset = MyDataset()
-basedir = "../data/CMS2018_nomixnocompress/hdf5_noPU_64x64/"
-#basedir = "../data/CMS2018_nomix/hdf5_noPU_64x64/"
+basedir = "../data/hdf5_32PU_64x64/"
 myDataset.addSample("RPV_1400", basedir+"RPV/Gluino1400GeV/*.h5", weight=0.013/330599)
 #myDataset.addSample("QCD_HT700to1000" , basedir+"QCD/HT700to1000/*/*.h5", weight=???)
 myDataset.addSample("QCD_HT1000to1500", basedir+"QCDBkg/HT1000to1500/*.h5", weight=1094./15466225)

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -29,9 +29,13 @@ parser.add_argument('--lr', action='store', type=float, default=1e-3, help='Lear
 parser.add_argument('--batchPerStep', action='store', type=int, default=1, help='Number of batches per step (to emulate all-reduce)')
 parser.add_argument('--shuffle', action='store', type=bool, default=True, help='Shuffle batches for each epochs')
 parser.add_argument('--optimizer', action='store', choices=('sgd', 'adam', 'radam', 'ranger'), default='adam', help='optimizer to run')
-parser.add_argument('--model', action='store', choices=('default', 'log3ch', 'log5ch', 'original', 'circpad', 'circpadlog3ch', 'circpadlog5ch'), 
+parser.add_argument('--model', action='store', choices=('default', 'defaultnorm', 'defaultnormcat',
+                                                        'log3ch', 'log3chnorm', 'log3chnormcat',
+                                                        'log5ch', 'log5chnorm', 'log5chnormcat',
+                                                        'original', 
+                                                        'circpad', 'circpadlog3ch', 'circpadlog5ch'), 
                                default='default', help='choice of model')
-parser.add_argument('--nreader', action='store', type=int, default=1, help='Number of loaders')
+parser.add_argument('--device', action='store', type=int, default=-1, help='device name')
 
 args = parser.parse_args()
 
@@ -42,7 +46,8 @@ if hvd:
     hvd_size = hvd.size()
     print("Horovod is available. (rank=%d size=%d)" % (hvd_rank, hvd_size))
     #torch.manual_seed(args.seed)
-    #torch.cuda.set_device(hvd.local_rank())
+    if torch.cuda.is_available(): torch.cuda.set_device(hvd.local_rank())
+if args.device >= 0: torch.cuda.set_device(args.device)
 
 if not os.path.exists(args.outdir): os.makedirs(args.outdir)
 modelFile = os.path.join(args.outdir, 'model.pkl')
@@ -75,7 +80,8 @@ from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
 sysstat.update(annotation="add samples")
 myDataset = MyDataset()
-basedir = "../data/CMS2018_unmerged/hdf5_noPU/"
+basedir = "../data/CMS2018_nomixnocompress/hdf5_noPU_64x64/"
+#basedir = "../data/CMS2018_nomix/hdf5_noPU_64x64/"
 myDataset.addSample("RPV_1400", basedir+"RPV/Gluino1400GeV/*.h5", weight=0.013/330599)
 #myDataset.addSample("QCD_HT700to1000" , basedir+"QCD/HT700to1000/*/*.h5", weight=???)
 myDataset.addSample("QCD_HT1000to1500", basedir+"QCDBkg/HT1000to1500/*.h5", weight=1094./15466225)
@@ -86,7 +92,7 @@ myDataset.setProcessLabel("QCD_HT1000to1500", 0) ## This is not necessary becaus
 myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0
 myDataset.setProcessLabel("QCD_HT2000toInf", 0) ## This is not necessary because the default is 0
 sysstat.update(annotation="init dataset")
-myDataset.initialize(nWorkers=args.nreader, logger=sysstat)
+myDataset.initialize(logger=sysstat)
 
 sysstat.update(annotation="split dataset")
 lengths = [int(0.6*len(myDataset)), int(0.2*len(myDataset))]
@@ -95,10 +101,11 @@ torch.manual_seed(123456)
 trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)
 torch.manual_seed(torch.initial_seed())
 
-kwargs = {'num_workers':min(4, nthreads)}
-if torch.cuda.is_available():
-    #if hvd: kwargs['num_workers'] = 1
-    kwargs['pin_memory'] = True
+kwargs = {'num_workers':1, 'pin_memory':False}
+#kwargs = {'num_workers':min(4, nthreads), 'pin_memory':False}
+#if torch.cuda.is_available():
+#    #if hvd: kwargs['num_workers'] = 1
+#    kwargs['pin_memory'] = True
 
 if hvd:
     trnSampler = torch.utils.data.distributed.DistributedSampler(trnDataset, num_replicas=hvd_size, rank=hvd_rank)

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -80,7 +80,8 @@ from HEPCNN.dataset_hepcnn import HEPCNNDataset as MyDataset
 
 sysstat.update(annotation="add samples")
 myDataset = MyDataset()
-basedir = "../data/hdf5_32PU_64x64/"
+#basedir = "../data/hdf5_noPU_224x224/"
+basedir = "../data/hdf5_32PU_224x224/"
 myDataset.addSample("RPV_1400", basedir+"RPV/Gluino1400GeV/*.h5", weight=0.013/330599)
 #myDataset.addSample("QCD_HT700to1000" , basedir+"QCD/HT700to1000/*/*.h5", weight=???)
 myDataset.addSample("QCD_HT1000to1500", basedir+"QCDBkg/HT1000to1500/*.h5", weight=1094./15466225)
@@ -100,8 +101,8 @@ torch.manual_seed(123456)
 trnDataset, valDataset, testDataset = torch.utils.data.random_split(myDataset, lengths)
 torch.manual_seed(torch.initial_seed())
 
-kwargs = {'num_workers':1, 'pin_memory':False}
-#kwargs = {'num_workers':min(4, nthreads), 'pin_memory':False}
+kwargs = {'num_workers':min(4, nthreads), 'pin_memory':False}
+#kwargs = {'pin_memory':True}
 #if torch.cuda.is_available():
 #    #if hvd: kwargs['num_workers'] = 1
 #    kwargs['pin_memory'] = True
@@ -114,7 +115,7 @@ if hvd:
 else:
     trnLoader = DataLoader(trnDataset, batch_size=args.batch, shuffle=args.shuffle, **kwargs)
     #valLoader = DataLoader(valDataset, batch_size=args.batch, shuffle=args.shuffle, **kwargs)
-    valLoader = DataLoader(valDataset, batch_size=512, shuffle=False, **kwargs)
+    valLoader = DataLoader(valDataset, batch_size=args.batch, shuffle=False, **kwargs)
 
 ## Build model
 sysstat.update(annotation="Model start")

--- a/run/train_labelByUser.py
+++ b/run/train_labelByUser.py
@@ -29,7 +29,7 @@ parser.add_argument('--lr', action='store', type=float, default=1e-3, help='Lear
 parser.add_argument('--batchPerStep', action='store', type=int, default=1, help='Number of batches per step (to emulate all-reduce)')
 parser.add_argument('--shuffle', action='store', type=bool, default=True, help='Shuffle batches for each epochs')
 parser.add_argument('--optimizer', action='store', choices=('sgd', 'adam', 'radam', 'ranger'), default='adam', help='optimizer to run')
-parser.add_argument('--model', action='store', choices=('default', 'defaultabs', 'defaultcat',
+parser.add_argument('--model', action='store', choices=('default', 'defaultfixed', 'defaultcat', 'defaultfixedcat',
                                                         'log3ch', 'log3chabs', 'log3chcat',
                                                         'log5ch', 'log5chabs', 'log5chcat',
                                                         'original', 
@@ -85,8 +85,8 @@ basedir = "../data/hdf5_32PU_224x224/"
 myDataset.addSample("RPV_1400", basedir+"RPV/Gluino1400GeV/*.h5", weight=0.013/330599)
 #myDataset.addSample("QCD_HT700to1000" , basedir+"QCD/HT700to1000/*/*.h5", weight=???)
 myDataset.addSample("QCD_HT1000to1500", basedir+"QCDBkg/HT1000to1500/*.h5", weight=1094./15466225)
-myDataset.addSample("QCD_HT1500to2000", basedir+"QCDBkg/HT1500to2000/*.h5", weight=99.16/3199737)
-myDataset.addSample("QCD_HT2000toInf" , basedir+"QCDBkg/HT2000toInf/*.h5", weight=20.25/1520178)
+myDataset.addSample("QCD_HT1500to2000", basedir+"QCDBkg/HT1500to2000/*.h5", weight=99.16/3368613)
+myDataset.addSample("QCD_HT2000toInf" , basedir+"QCDBkg/HT2000toInf/*.h5", weight=20.25/3250016)
 myDataset.setProcessLabel("RPV_1400", 1)
 myDataset.setProcessLabel("QCD_HT1000to1500", 0) ## This is not necessary because the default is 0
 myDataset.setProcessLabel("QCD_HT1500to2000", 0) ## This is not necessary because the default is 0

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -75,8 +75,8 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
     image_t = data['histtrack']
 
     ## Preprocess image
-    image_e /= np.max(image_e)
-    image_t /= np.max(image_t)
+    #image_e /= np.max(image_e)
+    #image_t /= np.max(image_t)
 
     if args.debug and iSrcFile == 0:
         print("Build multi-channels image...")

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -20,7 +20,8 @@ parser.add_argument('-d', '--debug', action='store_true', default=False, help='d
 args = parser.parse_args()
 
 srcFileNames = [x for x in args.input if x.endswith('.h5')]
-outPrefix, outSuffix = args.output.rsplit('.', 1)
+if not args.output.endswith('.h5'): outPrefix, outSuffix = 'data', '.h5'
+else: outPrefix, outSuffix = args.output.rsplit('.', 1)
 args.nevent = max(args.nevent, -1) ## nevent should be -1 to process everything or give specific value
 
 ## Logic for the arguments regarding on splitting

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -131,9 +131,10 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
             with h5py.File(outFileName, 'w', libver='latest') as outFile:
                 g = outFile.create_group('all_events')
                 kwargs = {} if args.nocompress else {'compression':'gzip', 'compression_opts':9}
+                kwargs['dtype'] = 'f4'
                 g.create_dataset('images', data=out_image, chunks=((chunkSize,)+out_image.shape[1:]), **kwargs)
-                g.create_dataset('labels', data=out_labels, chunks=(chunkSize,))
-                g.create_dataset('weights', data=out_weights, chunks=(chunkSize,))
+                g.create_dataset('labels', data=out_labels, chunks=(chunkSize,), dtype='i4')
+                g.create_dataset('weights', data=out_weights, chunks=(chunkSize,), dtype='f4')
                 outFile.swmr_mode = True
                 if args.debug: print("  done")
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -59,6 +59,7 @@ print("@@@ Total %d events to process, store into %d files (%d events per file)"
 
 print("@@@ Start processing...")
 outFileNames = []
+nEventProcessed = 0
 nEventToGo = nEventOutFile
 out_labels, out_weights, out_image = None, None, None
 for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
@@ -109,6 +110,7 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
 
         ## Do the processing
         nEventToGo -= (end-begin)
+        nEventProcessed += (end-begin)
 
         out_labels = np.concatenate([out_labels, labels[begin:end]])
         out_weights = np.concatenate([out_weights, weights[begin:end]])
@@ -116,7 +118,7 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
 
         begin, end = end, min(nEventToGo, nEvent0)
 
-        if nEventToGo <= 0 or len(outFileNames) == args.nfiles-1: ## Flush output and continue
+        if nEventToGo == 0 or nEventProcessed == nEventTotal: ## Flush output and continue
             nEventToGo = nEventOutFile
             end = min(begin+nEventToGo, nEvent0)
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -24,7 +24,7 @@ srcFileNames = [x for x in args.input if x.endswith('.h5')]
 if not args.output.endswith('.h5'): outPrefix, outSuffix = args.output+'/data', '.h5'
 else: outPrefix, outSuffix = args.output.rsplit('.', 1)
 args.nevent = max(args.nevent, -1) ## nevent should be -1 to process everything or give specific value
-precision = 'f%d' % (args.precision/8)
+precision = 'f%d' % (args.precision//8)
 
 ## Logic for the arguments regarding on splitting
 ##   split off: we will simply ignore nfiles parameter => reset nfiles=1
@@ -130,17 +130,16 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
             if args.debug: print("Writing output file %s..." % outFileName, end='')
 
             chunkSize = min(args.chunk, out_weights.shape[0])
-            with h5py.File(outFileName, 'w', libver='latest') as outFile:
+            with h5py.File(outFileName, 'w', libver='latest', swmr=True) as outFile:
                 g = outFile.create_group('all_events')
                 kwargs = {} if args.nocompress else {'compression':'gzip', 'compression_opts':9}
                 kwargs['dtype'] = precision
                 g.create_dataset('images', data=out_image, chunks=((chunkSize,)+out_image.shape[1:]), **kwargs)
                 g.create_dataset('labels', data=out_labels, chunks=(chunkSize,), dtype='f4')
                 g.create_dataset('weights', data=out_weights, chunks=(chunkSize,), dtype='f4')
-                outFile.swmr_mode = True
                 if args.debug: print("  done")
 
-            with h5py.File(outFileName, 'r') as outFile:
+            with h5py.File(outFileName, 'r', libver='latest', swmr=True) as outFile:
                 print(("  created %s (%d/%d)" % (outFileName, iOutFile, args.nfiles)), end='')
                 print("  keys=", list(outFile.keys()), end='')
                 print("  shape=", outFile['all_events']['images'].shape)
@@ -149,5 +148,5 @@ for iSrcFile, (nEvent0, srcFileName) in enumerate(zip(nEvent0s, srcFileNames)):
 
 if args.debug:
     for outFileName in outFileNames:
-        f = h5py.File(outFileName, 'r')
+        f = h5py.File(outFileName, 'r', libver='latest', swmr=True)
         print(outFileName, f['all_events/images'].shape)

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -20,7 +20,7 @@ parser.add_argument('-d', '--debug', action='store_true', default=False, help='d
 args = parser.parse_args()
 
 srcFileNames = [x for x in args.input if x.endswith('.h5')]
-if not args.output.endswith('.h5'): outPrefix, outSuffix = args.output+'data', '.h5'
+if not args.output.endswith('.h5'): outPrefix, outSuffix = args.output+'/data', '.h5'
 else: outPrefix, outSuffix = args.output.rsplit('.', 1)
 args.nevent = max(args.nevent, -1) ## nevent should be -1 to process everything or give specific value
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -20,7 +20,7 @@ parser.add_argument('-d', '--debug', action='store_true', default=False, help='d
 args = parser.parse_args()
 
 srcFileNames = [x for x in args.input if x.endswith('.h5')]
-if not args.output.endswith('.h5'): outPrefix, outSuffix = 'data', '.h5'
+if not args.output.endswith('.h5'): outPrefix, outSuffix = args.output+'data', '.h5'
 else: outPrefix, outSuffix = args.output.rsplit('.', 1)
 args.nevent = max(args.nevent, -1) ## nevent should be -1 to process everything or give specific value
 


### PR DESCRIPTION
#### Preprocessor:
- Bugfix: preprocessor 실행시 마지막 파일에서 이벤트를 스킵하는 문제가 있었음
- Feature: image를 normlize할 때 로딩 된 이미지에 대해서만 max를 취함. file split하는 경우 어떤 파일들이 로딩되어 있느냐에 따라 결과가 달라짐. 이 단계에서는 normalization을 하지 않고 training시에 model에서 하는 편이 나아보임.
- Feature: output을 directory로 입력하면 data_*.h5를 기본값으로 사용.
- Compression algorithm자체를 유저가 선택하도록 변경 - LZ4가 가장 빠르므로 이를 권장함. chunk size는 1이 적당해 보임.

#### Training
- Change behaviour: 초기 로딩 단계에서 파일의 모든 내용을 tensor로 변환해 in-memory로 처리하던 것을 hdf에서 on-demand로 로딩해 처리하는 방식으로 변경함 (input hdf파일이 압축되지 않아야 함 -> chunk 1인 LZ4면 괜찮음.)
- pytorch의 dataloader에서의 multiprocessing기능을 사용할 수 있게 함. 구현시 주의사항으로, class내에서 HDF파일이 열린채로 process fork나 spawn이 일어나는 경우 압축 해제 문제나 파일 접근 불가 메시지가 나타남. multiproc으로 class가 복사 된 이후에 파일을 열어야 하므로 __getitem__()에서 최초 파일 접근 시에 파일 핸들을 열어두는 방식으로 구현해야 함.
- Feature: image를 normlize할 때 로딩 된 이미지에 대해서만 max를 취함. file split하는 경우 어떤 파일들이 로딩되어 있느냐에 따라 결과가 달라짐. 이 단계에서는 normalization을 하지 않고 training시에 model에서 하는 편이 나아보임. 모델에서 "cat" 이 있으면 max값을 concatenate하고, "fixed"가 있으면 scale하지 않고 abs값을 사용하는 식으로 변경함. 기존의 default모델은 scale하고 cat하지 않는 경우와 비슷함.
- genevent 수를 고침.