### PR TITLE
bug fix...

### DIFF
--- a/python/HEPCNN/torch_model_largekernel.py
+++ b/python/HEPCNN/torch_model_largekernel.py
@@ -33,13 +33,13 @@ class MyModel(nn.Module):
             CircularPadX(1),
             nn.Conv2d(self.nch, 64, kernel_size=(14, 14), stride=1, padding=(1,0)), ## padding=(height,width)
 
-            nn.MaxPool2d(kernel_size=(14, 14)),
+            nn.MaxPool2d(kernel_size=(21, 21)),
             nn.ReLU(),
             nn.BatchNorm2d(num_features=64, eps=0.001, momentum=0.99),
             nn.Dropout2d(0.5),
         ])
-        self.fh = self.fh//2
-        self.fw = self.fw//2
+        self.fh = self.fh//28
+        self.fw = self.fw//28
 
         self.conv.extend([
             CircularPadX(1),


### PR DESCRIPTION
기존의 코드에서는 80번째 줄에서 
RuntimeError: size mismatch, m1: [8 x 2304], m2: [4096 x 512] at /tmp/pip-req-build-4baxydiv/aten/src/THC/generic/THCTensorMathBlas.cu:290
위와 같은 에러가 나타났습니다
conv2d 에서 kernel size가 14일때(large kernel일때) 나타나던 에러로, 레이어를 모두 통과한 후 텐서의 크기가 맞지 않았습니다.
이때 MaxPool2d와 첫 self.fh 및 self.fw의 크기를 수정된 코드와 같이 수정하면 위의 에러를 해결할 수 있습니다.